### PR TITLE
Update whitelist.txt to fix two websites that broke

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -374,6 +374,7 @@ chrome.google.com
 cint.com
 cisco.com
 classmates.com
+cldup.com
 click.cptrack.de
 click.discord.com
 click.e.change.org
@@ -1938,6 +1939,7 @@ tuba.fm
 tumblr.com
 tunein.com
 tusfiles.net
+turbolab.it
 tuttobasket.net
 tuttomercatoweb.com
 tuttosport.com


### PR DESCRIPTION
Added two domains to the white list that prevented the loading of some sites: 
- cldup.com prevents the loading of cloudup.com
- turbolab.it prevents the loading of the Italian Informatic site