### PR TITLE
Update whitelist.txt

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -796,6 +796,7 @@ gfwsl.geforce.com
 gfycat.com
 ghcr.io
 ghost.spam.howto
+giardiniblog.it
 gigaom.com
 giphy.com
 gist.github.com
@@ -1922,6 +1923,7 @@ tofukko.r.ribbon.to
 token.safebrowsing.apple
 tomshardware.com
 tools.pingdom.com
+toonitalia.xyz
 torrentfreak.com
 toysrus.com
 tra.scds.pmdstatic.net


### PR DESCRIPTION
Added two domains to the white list that prevented the loading of some sites: 
- giardiniblog.it prevents the loading of an Italian general blog site.
- toonitalia.xyz prevents the loading of the Italian site that contains cartoons and TV series from the 80s and 90s.