### PR TITLE
Guard against missing tar.gz extraction

### DIFF
--- a/scripts/update_rpz_blacklist.sh
+++ b/scripts/update_rpz_blacklist.sh
@@ -29,7 +29,16 @@ mkdir -p "$RPZ_DIRECTORY"
 wget -O "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" "$RPZ_URL"
 
 # Extract the blacklist
-tar -xzf "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" -C "$RPZ_DIRECTORY"
+if ! tar -xzf "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" -C "$RPZ_DIRECTORY"; then
+    echo "Error: Failed to extract rpz_blacklist.tar.gz. Exiting."
+    exit 1
+fi
+
+# Verify that the expected output file exists
+if [ ! -f "$RPZ_DIRECTORY/rpz_blacklist.txt" ]; then
+    echo "Error: Extraction failed; expected file rpz_blacklist.txt not found. Exiting."
+    exit 1
+fi
 
 # Check if the configuration is already added to avoid duplicate entries
 if ! grep -q "rpz.blacklist" "$BIND_CONFIG"; then


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/update_rpz_blacklist.sh`

**Rationale:** The script fails silently if the tar extraction is skipped or fails, leaving the expected 'rpz_blacklist.txt' file missing. This causes the subsequent BIND configuration to reference a non-existent file, leading to a confusing 'Error in BIND configuration' rather than a clear indication that the download/extract step failed.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `a889bfc798a06ae3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a889bfc798a06ae3","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":49.63,"prompt_sha":"27d93c3a6e8ae4d0","triage":"INFO"} -->