### PR TITLE
Skip empty lines and comments in blacklist input

### DIFF
--- a/scripts/nft_blacklist_fqdn.sh
+++ b/scripts/nft_blacklist_fqdn.sh
@@ -34,6 +34,8 @@ fi
   echo "    chain $CHAIN_NAME {"
 
   while IFS= read -r domain || [[ -n "$domain" ]]; do
+    # Skip empty lines and comments
+    [[ -z "$domain" || "$domain" =~ ^[[:space:]]*# ]] && continue
     validate_domain "$domain"
     echo "        drop ip daddr $domain"
     echo "        drop ip saddr $domain"


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/nft_blacklist_fqdn.sh`

**Rationale:** The script currently fails on empty lines or comment lines (e.g., starting with #) in the downloaded blacklist, because validate_domain() will reject them as invalid domains. Real-world blacklists often include such non-domain lines, so skipping them improves robustness without changing intended behavior.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `196fbe733fa6c1e4` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"196fbe733fa6c1e4","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":9.7,"prompt_sha":"f2cfef45601ccb57","triage":"INFO"} -->