### PR TITLE
privacy: link the shared privacy notice + meta-CSP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'">
     <title>Domains Blacklist - Daily Updated Cybersecurity Protection</title>
     <meta name="description"
         content="Daily updated domains blacklist with 2.9M+ blocked threats. Open-source cybersecurity for everyone.">
@@ -392,6 +393,7 @@
                 <p>&copy; 2025 Domains Blacklist. Open-source project by <a href="https://github.com/fabriziosalmi"
                         target="_blank">@fabriziosalmi</a></p>
                 <p>Licensed under MIT. Updated daily with ❤️ for the cybersecurity community.</p>
+                <p><a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a></p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
This site had **no privacy notice**. It now links the canonical one published once for every project site on this host:

### 🔗 https://fabriziosalmi.github.io/privacy

That notice is accurate here as-is: same publisher, same host (GitHub Pages), no cookies, no analytics. One document to maintain instead of a copy per repository.

## Changes
- **Footer** — a `Privacy & legal` link.
- **meta-CSP** — `default-src 'self'`.

## Verified in a browser
| Check | Result |
|---|---|
| Third-party origins | **`[]` — zero** |
| Privacy link | ✅ present |
| CSP violations | **none** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)