### PR TITLE
Fix hardcoded RPZ directory path causing script failure

### DIFF
--- a/scripts/update_rpz_blacklist.sh
+++ b/scripts/update_rpz_blacklist.sh
@@ -16,7 +16,7 @@ for cmd in "${REQUIRED_COMMANDS[@]}"; do
 done
 
 # Directory to store the RPZ blacklist
-RPZ_DIRECTORY="/path/to/store/rpz_blacklist"
+RPZ_DIRECTORY="/var/lib/bind/rpz_blacklist"
 # URL of the RPZ blacklist
 RPZ_URL="https://github.com/fabriziosalmi/blacklists/raw/main/rpz_blacklist.tar.gz"
 # BIND configuration file


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/update_rpz_blacklist.sh`

**Rationale:** The script uses a hardcoded placeholder path `/path/to/store/rpz_blacklist` for `RPZ_DIRECTORY`, which will cause `mkdir`, `wget`, `tar`, and `named-checkconf` to fail in real deployments since that path almost certainly doesn't exist or isn't writable. This is a real, demonstrable defect visible in the file — the script will always fail unless the user manually edits the script to replace the placeholder, which defeats automation.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `a889bfc798a06ae3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a889bfc798a06ae3","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":5.74,"prompt_sha":"94e244cfd0ab8fba","triage":"INFO"} -->