### PR TITLE
Fix missing error handling for tar extraction failure

### DIFF
--- a/scripts/update_rpz_blacklist.sh
+++ b/scripts/update_rpz_blacklist.sh
@@ -26,7 +26,10 @@ BIND_CONFIG="/etc/bind/named.conf.local"
 mkdir -p "$RPZ_DIRECTORY"
 
 # Download the latest RPZ blacklist from the repository
-wget -O "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" "$RPZ_URL"
+if ! wget -O "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" "$RPZ_URL"; then
+    echo "Error: Failed to download rpz_blacklist.tar.gz. Exiting."
+    exit 1
+fi
 
 # Extract the blacklist
 if ! tar -xzf "$RPZ_DIRECTORY/rpz_blacklist.tar.gz" -C "$RPZ_DIRECTORY"; then


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/update_rpz_blacklist.sh`

**Rationale:** The script extracts the downloaded tarball but only checks if tar extraction fails via its exit code; however, if the tarball is corrupted or incomplete (e.g., due to network issues), wget may succeed (exit 0) but produce a broken archive, and tar may fail silently or partially. The current code checks tar's exit code, but does not verify the integrity of the downloaded file before extraction. A more critical issue is that wget may fail to download the file (e.g., 404, timeout), but the script does not check wget's exit code — it proceeds to extract regardless, which will cause tar to fail on a missing or empty file. This is a real defect because wget's exit status is never checked, and the script will proceed to extract even if the download failed.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `a889bfc798a06ae3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a889bfc798a06ae3","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":5.95,"prompt_sha":"a8767b89916a892a","triage":"INFO"} -->