### PR TITLE
Guard against empty RPZ blacklist file after extraction

### DIFF
--- a/scripts/update_rpz_blacklist.sh
+++ b/scripts/update_rpz_blacklist.sh
@@ -43,6 +43,12 @@ if [ ! -f "$RPZ_DIRECTORY/rpz_blacklist.txt" ]; then
     exit 1
 fi
 
+# Verify that the blacklist file is non-empty
+if [ ! -s "$RPZ_DIRECTORY/rpz_blacklist.txt" ]; then
+    echo "Error: rpz_blacklist.txt is empty. Exiting."
+    exit 1
+fi
+
 # Check if the configuration is already added to avoid duplicate entries
 if ! grep -q "rpz.blacklist" "$BIND_CONFIG"; then
     # Append configuration to BIND's config file


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/update_rpz_blacklist.sh`

**Rationale:** The script extracts a tarball and checks for the existence of rpz_blacklist.txt, but does not verify that the file is non-empty. If the downloaded tarball is corrupted or the upstream source provides an empty file, BIND will fail to load the zone with a cryptic error. This is a real defect because the script proceeds to run named-checkconf and exits successfully even if the blacklist file is empty, leading to a misconfigured DNS service.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `a889bfc798a06ae3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a889bfc798a06ae3","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":2,"inference_s":12.42,"prompt_sha":"d111d3b85f78386c","triage":"INFO"} -->